### PR TITLE
feat: JSON-LD Organization schema & sitemap.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env*.local

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -59,6 +59,20 @@ export const metadata: Metadata = {
   },
 };
 
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "ShiftClaw",
+  url: siteUrl,
+  logo: `${siteUrl}/logo.png`,
+  description:
+    "An indie studio where human creativity meets AI execution. Building SaaS tools that solve real problems.",
+  sameAs: [
+    "https://x.com/ShiftClawCO",
+    "https://github.com/ShiftClawCO",
+  ],
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -66,6 +80,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const siteUrl = "https://shiftclawco.com";
+
+  return [
+    {
+      url: siteUrl,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+  ];
+}


### PR DESCRIPTION
## Changes
- Added JSON-LD Organization structured data in layout.tsx (name, url, logo, sameAs)
- Added sitemap.ts for automatic /sitemap.xml generation
- Issues #1-#5 already closed (deployed previously)

Resolves #7

## Verification
- `npm run build` passes ✅
- /sitemap.xml route generated ✅
- JSON-LD in HTML output ✅