### PR TITLE
chore(css): remove unused sidebar + chart CSS variables

### DIFF
--- a/spec/prd/css-cleanup/19/spec.md
+++ b/spec/prd/css-cleanup/19/spec.md
@@ -1,0 +1,30 @@
+# Issue #19 — Remove unused CSS variables (sidebar + chart)
+
+## Summary
+Remove ~34 unused CSS custom properties from `globals.css`: 24 `--sidebar-*` variables and 10 `--chart-*` variables. No sidebar or chart components exist in the landing site.
+
+## Architecture Analysis
+
+### Affected Files
+- `src/app/globals.css` — sole file to modify
+
+### Variables to Remove
+**Sidebar** (in `@theme`, `:root`, `.dark`):
+`--sidebar`, `--sidebar-foreground`, `--sidebar-primary`, `--sidebar-primary-foreground`, `--sidebar-accent`, `--sidebar-accent-foreground`, `--sidebar-border`, `--sidebar-ring`, and any `--color-sidebar-*` references.
+
+**Chart** (in `:root` and `.dark`):
+`--chart-1` through `--chart-5`, and any `--color-chart-*` references.
+
+### Risk Assessment
+- **Risk**: None — these variables are unused scaffold defaults from shadcn/ui init
+- **Regression**: Zero — no component references these variables
+- **Rollback**: Trivial — revert single commit
+
+## Acceptance Criteria
+- `grep -c 'sidebar' src/app/globals.css` returns 0
+- `grep -c 'chart' src/app/globals.css` returns 0
+- `npx next build` passes without errors
+- No visual regression
+
+## Testable Elements
+None — CSS-only change with no UI components affected.

--- a/spec/prd/css-cleanup/19/tasks.md
+++ b/spec/prd/css-cleanup/19/tasks.md
@@ -1,0 +1,10 @@
+# Tasks — Issue #19
+
+- [x] Remove all `--sidebar-*` and `--color-sidebar-*` variables from `@theme` inline block in globals.css
+- [x] Remove all `--sidebar-*` variables from `:root` block in globals.css
+- [x] Remove all `--sidebar-*` variables from `.dark` block in globals.css
+- [x] Remove all `--chart-*` and `--color-chart-*` variables from `:root` block in globals.css
+- [x] Remove all `--chart-*` and `--color-chart-*` variables from `.dark` block in globals.css
+- [x] Verify: `grep -c 'sidebar' src/app/globals.css` returns 0
+- [x] Verify: `grep -c 'chart' src/app/globals.css` returns 0
+- [x] Build passes: `npm run build`

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,19 +8,6 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
@@ -66,19 +53,6 @@
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
@@ -100,19 +74,6 @@
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- Remove 34 unused CSS custom properties from `globals.css` (sidebar + chart variables)
- Cleans up ~39 lines of dead CSS from shadcn/ui scaffold defaults
- No sidebar or chart components exist in the landing site

## Changes
- `src/app/globals.css` — removed `--sidebar-*`, `--color-sidebar-*`, `--chart-*`, `--color-chart-*` from `@theme inline`, `:root`, and `.dark` blocks

## Verification
- `grep -c 'sidebar' src/app/globals.css` → 0
- `grep -c 'chart' src/app/globals.css` → 0
- `npm run build` → PASS (compiled in 4.2s, all routes generated)

Resolves #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)