### PR TITLE
fix: remove duplicate XIcon import

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,6 @@ import { ThemeToggle } from "@/components/theme-toggle"
 import { MobileNav } from "@/components/mobile-nav"
 import { XIcon } from "@/components/icons/x-icon"
 import { ArrowRight, Zap, Users, Bot, Mail, FileText, Github, MessageCircle } from "lucide-react"
-import { XIcon } from "@/components/icons/x-icon"
 import Link from "next/link"
 
 export default function Home() {


### PR DESCRIPTION
## Summary
- Fix duplicate XIcon import in page.tsx that caused Vercel production build failure

Hotfix for deploy.